### PR TITLE
Add aks package

### DIFF
--- a/azgo/aks/aks.go
+++ b/azgo/aks/aks.go
@@ -1,0 +1,50 @@
+package aks
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/containerservice/armcontainerservice"
+)
+
+// RunCommand runs a command on an AKS cluster
+// specified via its subscription, resource group,
+// and cluster name. The command is a string which
+// is run inside a container on the cluster itself.
+// This command authenticates against Azure via the
+// DefaultAzureCredential (see: https://docs.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication?tabs=bash#3-use-defaultazurecredential-to-authenticate-resourceclient ) in the azidentity package.
+func RunCommand(subscriptionID, resourceGroup, resourceName, command string) (string, error) {
+
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		return "", err
+	}
+
+	con := arm.NewDefaultConnection(cred, nil)
+	if err != nil {
+		return "", err
+	}
+
+	client := armcontainerservice.NewManagedClustersClient(con, subscriptionID)
+
+	ctx := context.Background()
+	request := armcontainerservice.RunCommandRequest{}
+	request.Command = &command
+
+	result, err := client.BeginRunCommand(ctx, resourceGroup, resourceName, request, nil)
+	if err != nil {
+		return "", err
+	}
+	res, err := result.PollUntilDone(ctx, 5*time.Second)
+	if err != nil {
+		return "", err
+	}
+	b, err := json.Marshal(res.RunCommandResult)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}

--- a/azgo/aks/aks_test.go
+++ b/azgo/aks/aks_test.go
@@ -1,0 +1,34 @@
+package aks
+
+import (
+	"log"
+	"os"
+	"testing"
+)
+
+var subscriptionID string
+
+func init() {
+	subscriptionID = os.Getenv("AZURE_SUBSCRIPTION")
+	if subscriptionID == "" {
+		log.Fatal("AZURE_SUBSCRIPTION environment variable not set!")
+	}
+}
+
+func TestRunCommand(t *testing.T) {
+	resourceGroup := os.Getenv("RESOURCE_GROUP")
+	if resourceGroup == "" {
+		log.Fatal("RESOURCE_GROUP not set.")
+	}
+	clusterName := os.Getenv("AKS_NAME")
+	if clusterName == "" {
+		log.Fatal("AKS_NAME not set")
+	}
+	command := "kubectl run nginx --image=nginx"
+	res, err := RunCommand(subscriptionID, resourceGroup, clusterName, command)
+	log.Println(res)
+	if err != nil {
+		t.Error(err)
+	}
+	_ = res
+}

--- a/azgo/aks/doc.go
+++ b/azgo/aks/doc.go
@@ -1,0 +1,5 @@
+/*
+Package aks uses the Azure SDK for Go's armcontainerservice package to work with
+Azure Kubernetes Service (AKS) clusters.
+*/
+package aks

--- a/azgo/arm/arm_test.go
+++ b/azgo/arm/arm_test.go
@@ -9,7 +9,7 @@ import (
 var subscriptionID string
 
 func init() {
-	subscriptionID := os.Getenv("AZURE_SUBSCRIPTION")
+	subscriptionID = os.Getenv("AZURE_SUBSCRIPTION")
 	if subscriptionID == "" {
 		log.Fatal("AZURE_SUBSCRIPTION environment variable not set!")
 	}

--- a/azgo/do/az-aks-env.sh
+++ b/azgo/do/az-aks-env.sh
@@ -1,0 +1,3 @@
+export AZURE_SUBSCRIPTION=$(az account show | jq -r '.id')
+export RESOURCE_GROUP='210900-aks'
+export AKS_NAME='aks1'

--- a/azgo/go.mod
+++ b/azgo/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/armcore v0.8.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.19.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.11.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/containerservice/armcontainerservice v0.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/data/aztables v0.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resources/armresources v0.3.0 // indirect

--- a/azgo/go.sum
+++ b/azgo/go.sum
@@ -68,6 +68,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azcore v0.19.0/go.mod h1:h6H6c8enJmmocHUbL
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.10.0/go.mod h1:HcM1YX14R7CJcghJGOYCgdezslRSVzqwLf/q+4Y2r/0=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.11.0 h1:OYa9vmRX2XC5GXRAzeggG12sF/z5D9Ahtdm9EJ00WN4=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.11.0/go.mod h1:HcM1YX14R7CJcghJGOYCgdezslRSVzqwLf/q+4Y2r/0=
+github.com/Azure/azure-sdk-for-go/sdk/containerservice/armcontainerservice v0.2.0 h1:581MLJElPjgiuEoRGzOvnk+8q3haOWHqyWIU2KIbUO4=
+github.com/Azure/azure-sdk-for-go/sdk/containerservice/armcontainerservice v0.2.0/go.mod h1:hGbqXUPvb2aM2t5x0Wnp8Q2KPacYWmNWVzjNCvqFc1s=
 github.com/Azure/azure-sdk-for-go/sdk/data/aztables v0.1.0 h1:atG1xcAQo7PXdWCEgLWVw+YKQlVdyjUNt3XHOGvIIPg=
 github.com/Azure/azure-sdk-for-go/sdk/data/aztables v0.1.0/go.mod h1:H2blut9zM8tWsRM/RxtT8N8wupJJiDxcOgkmeSD/1aQ=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1/go.mod h1:k4KbFSunV/+0hOHL1vyFaPsiYQ1Vmvy1TBpmtvCDLZM=


### PR DESCRIPTION
This PR introduces a new package, aks, with a single function, `RunCommand`, which uses the Azure SDK for Go to trigger the Managed Clusters - Run Command (https://docs.microsoft.com/en-us/rest/api/aks/managed-clusters/run-command ) REST endpoint.